### PR TITLE
Fix getTransition() error when transitions property is undefined

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -138,6 +138,10 @@ export default class Helpers {
    * @static
    */
   getTransition(slug) {
+    if (!this.transitions) {
+      return null;
+    }
+
     if (!(slug in this.transitions)) {
       if ('default' in this.transitions) {
         return this.transitions['default'];


### PR DESCRIPTION
Fix `Cannot use 'in' operator to search for 'home' in undefined` when `Highway.Core` is initialized without transitions parameter.