### PR TITLE
Make possible to pass renderer promise

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -35,8 +35,11 @@ export default class Core extends Emitter {
     this.cache.set(this.location.pathname, this.properties);
 
     // Get the page renderer and properly setup it.
-    this.From = new this.properties.renderer(this.properties);
-    this.From.setup();
+    this.properties.renderer
+      .then(Renderer => {
+        this.From = new Renderer(this.properties);
+        this.From.setup();
+      });
 
     // Events variables.
     this._navigate = this.navigate.bind(this);
@@ -216,7 +219,9 @@ export default class Core extends Emitter {
   async afterFetch() {
     // We are calling the renderer attached to the view we just fetched and we
     // are adding the [data-router-view] in our DOM.
-    this.To = new this.properties.renderer(this.properties);
+    const Renderer = await this.properties.renderer;
+
+    this.To = new Renderer(this.properties);
     this.To.add();
 
     // We then emit a now event right before the view is shown to create a hook

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -127,7 +127,16 @@ export default class Helpers {
    * @static
    */
   getRenderer(slug) {
-    return slug in this.renderers ? this.renderers[slug] : Renderer;
+    if (slug in this.renderers) {
+      if (typeof this.renderers[slug].then === 'function') {
+        return Promise.resolve(this.renderers[slug])
+          .then(({default: cons}) => cons);
+      }
+
+      return Promise.resolve(this.renderers[slug]);
+    }
+
+    return Promise.resolve(Renderer);
   }
 
   /**


### PR DESCRIPTION
Allow `Highway.Core` renderers to be initialized with dynamic imports :

```javascript
const H = new Highway.Core({
  renderers: {
    home: import('./Home'),
    about: import('./About'),
    contact: import('./Contact')
  },
  transitions: {}
});
```

So `Renderer` classes are loaded when the user navigate to the page