### PR TITLE
Change renderer to append new view, and then remove old view.

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -11,7 +11,7 @@ export default class Renderer {
    */
   constructor(properties) {
     // We get the view.
-    this.view = document.querySelector('[data-router-view]');
+    this.view = document.querySelector('[data-router-wrapper]');
 
     // We save properties of the renderer
     this.properties = properties;
@@ -30,19 +30,12 @@ export default class Renderer {
   }
 
   /**
-   * Add view in DOM.
+   * Add view in DOM, then remove previous view
    */
   add() {
     // We setup the DOM for our [data-router-view]
-    this.view.setAttribute('data-router-view', this.properties.slug);
-    this.view.innerHTML = this.properties.view.innerHTML;
-  }
-
-  /**
-   * Remove view in DOM.
-   */
-  remove() {
-    this.view.innerHTML = '';
+    this.view.insertAdjacentHTML('beforeend', this.properties.view.outerHTML);
+    this.view.firstElementChild.remove();
   }
 
   /**
@@ -56,10 +49,11 @@ export default class Renderer {
 
   /**
    * Add the view in DOM and play an `in` transition if one is defined.
-   *
+   * 
+   * @param {(object|boolean)} contextualTransition - If the transition is changing on the fly
    * @return {object} Promise
    */
-  show() {
+  show(contextualTransition) {
     return new Promise(async resolve => {
       // Update DOM.
       this.update();
@@ -71,7 +65,7 @@ export default class Renderer {
       // The transition is set in your custom renderer with a getter called
       // `transition` that should return the transition object you want to
       // apply to you view. We call the `in` step of this one right now!
-      this.Transition && await this.Transition.show();
+      this.Transition && await this.Transition.show(contextualTransition);
 
       // The `onEnterCompleted` method if set in your custom renderer is called
       // everytime a transition is over if set. Otherwise it's called right after
@@ -85,10 +79,10 @@ export default class Renderer {
 
   /**
    * Play an `out` transition if one is defined and remove the view from DOM.
-   *
+   * @param {(object|boolean)} contextualTransition - If the transition is changing on the fly
    * @return {object} Promise
    */
-  hide() {
+  hide(contextualTransition) {
     return new Promise(async resolve => {
       // The `onLeave` method if set in your custom renderer is called everytime
       // before a view will be removed from the DOM. This let you do some stuffs
@@ -96,10 +90,7 @@ export default class Renderer {
       this.onLeave && this.onLeave();
 
       // We call the `out` step of your transition right now!
-      this.Transition && await this.Transition.hide();
-
-      // Remove view from DOM.
-      this.remove();
+      this.Transition && await this.Transition.hide(contextualTransition);
 
       // The `onLeaveCompleted` method if set in your custom renderer is called
       // everytime a view is completely removed from the DOM.


### PR DESCRIPTION
I don't expect you to merge this one for a release, but I thought you would find it interesting and perhaps others would find it useful. Also, if you want to merge it for a release I would love that 💯 

I'm a big fan of what you've built with highway and I'm a huge PJAX nerd. But as you know based on my past pull request, it was missing a couple crucial things that I needed. I added the contextualTransitions, and now I changed it so instead of removing the innerHTML of the view, and changing the `data-router-view` attribute, it first appends the new view after the old one, then removes the old one. This is crucial in order to have a transition that keeps elements from the previous view until the new view elements are ready to take it's place. This solves https://github.com/Dogstudio/highway/issues/17.

So in summary, views still have their transitions assigned, as well as a default transition of course. Contextual transitions can fire on click, and now the new view is appended to the `data-router-wrapper` before the old view is removed. Then the old view is removed. The reason for this is to achieve visual trickery. Sometimes you want an element that appears to persist across views. See this video of an early WIP to see what I mean: https://zero-1.wistia.com/medias/e1qvni1ndp... when you get to the bottom of a project, you click to go to the next project. The large text appears to stay and carry over to the next view, but in reality the next view just has the same text positioned in the same way. 

Before this wasn't possible, since there would be a flash of emptiness in-between the old content being removed and the new content added. Enjoy!