### PR TITLE
Add contextual transitions to core.redirect, overlapping views work, add contextualTransition example, small fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 **Highway** is a *lightweight (**2.2ko** gzipped)*, *robust*, *modern* and *flexible* library that will let us create **AJAX navigations** with beautiful **transitions** on our websites. It's been a while we were trying to build this kind of library to fits our needs at [**Dogstudio**](https://www.dogstudio.co) and we now finally released it!
 
+<p align="center"><a href="https://join.slack.com/t/highway-lib/shared_invite/enQtNDcxMzY5MDc0NDE3LWQyMWMwZjhiNDUxOWVkM2Y0MTkxMTY5ZTU3ZjRmNjU2ZTI3YjAwNGQ2ZTZlYTcyNTBhYWEzMGQyZGFlODY0MjY"target="_blank"><img src="https://i.imgur.com/4nWCfju.png" alt="Banner" /></a></p>
+
 ## Table of Content
 
 - [**Guide**](https://dogstudio.github.io/highway/)

--- a/docs/examples.html
+++ b/docs/examples.html
@@ -2,12 +2,15 @@
 slug: examples
 title: Highway - Examples
 layout: default
+next_url: ./demos.html
+next_label: Demos
 ---
 
 <h1>Examples</h1>
 <h2 id="forms"><a href="./examples.html#forms">Forms</a></h2>
-<p>Form submission is not considered as a navigation so it <strong>hard reloads</strong> the page by default. We have to consider using AJAX validation and the <em>Core</em>.<strong>redirect(<em>href</em>)</strong> method if we want to redirect our users to a <em>Thank you</em> page.</p>
-
+<p>Form submission is not considered as a navigation so it <strong>hard reloads</strong> the page by default. We have to consider using AJAX validation and the <em>Core</em>.<strong>redirect(<em>href</em>, <em>ContextualTransition</em>)</strong> method if we want to redirect our users to a <em>Thank you</em> page.
+    ContextualTransition can also be set to false to utilize the view transition. Try this out by hovering on the button below for 1.5 seconds to be taken to the API Reference page, using a contextual transition (more on that below).</p>
+<div class="button redirect-example">Hover me!</div>
 <h2 id="disable-links"><a href="./examples.html#disable-links">Disable Links</a></h2>
 <p>All links using with a different origin, a <strong>target</strong> attribute or a <strong>data-router-disabled</strong> attribute are going to be ignored by <strong>Highway</strong>. We have then some options in our hand to manipulate our links the way we want.</p>
 
@@ -70,3 +73,6 @@ layout: default
 <p>Depending on our websites we might have to deal with third-party scripts used by plugins or others. Those scripts have to be evaluated on each page transition in order to be runned again.</p>
 <p>Unfortunately there is a danger to evaluate malicious code and we cannot take the responsability of potential issues related to that. That's why we are never going to implement any evaluation method in <strong>Highway</strong>.</p>
 <p>Check out this <a href="https://github.com/Dogstudio/highway/issues/7#issuecomment-396161696" target="_blank">Github issue</a> to have more informations about this topic.</p>
+
+<h2 id="contextual">Contextual Transitions</h2>
+<p><a href="./get-started.html" class="button" data-transition="contextualExample">Try me!</a></p>

--- a/docs/src/js/main.js
+++ b/docs/src/js/main.js
@@ -6,8 +6,15 @@ import Highway from 'highway';
 
 // Transitions
 import Fade from 'transitions/fade';
+import Contextual from 'transitions/contextualExample';
 
 (() => {
+
+  // for clicking back and forward, we always want to drop them on the top of the page
+  if ('scrollRestoration' in history) {
+    history.scrollRestoration = 'manual';
+  }
+
   const $menuToggler = document.querySelector('.js-toggle-menu');
   const $siteHeader = document.querySelector('.js-site-header');
 
@@ -23,9 +30,34 @@ import Fade from 'transitions/fade';
       'installation': () => import('renderers/installation')
     },
     transitions: {
-      default: Fade
+      default: Fade,
+      contextual: {
+        contextualExample: Contextual
+      }
     }
   });
+
+  // this should probably be in examples.js somehow, but I ran out of time and needed access to the Highway.Core created above
+  const hoverRedirect = () => {
+    let hoveringButton = false;
+    let countdown;
+    const redirectButton = document.querySelector('.redirect-example');
+    if (redirectButton) {
+      redirectButton.addEventListener('mouseenter', () => {
+        hoveringButton = true;
+        countdown = setTimeout(() => {
+          if (hoveringButton === true) {
+            H.redirect('http://127.0.0.1:4000/api.html', 'contextualExample');
+          }
+        }, 1500);
+      });
+      redirectButton.addEventListener('mouseleave', () => {
+        hoveringButton = false;
+        clearTimeout(countdown);
+      });
+    }
+  };
+  hoverRedirect();
 
   // Events
   const links = document.querySelectorAll('.site-menu a');
@@ -43,6 +75,8 @@ import Fade from 'transitions/fade';
         link.classList.add('is-active');
       }
     }
+
+    hoverRedirect();
   });
 
   H.on('NAVIGATE_END', (to, from, location) => {

--- a/docs/src/js/transitions/contextualExample.js
+++ b/docs/src/js/transitions/contextualExample.js
@@ -7,19 +7,20 @@ import Tween from 'gsap';
 // Basic
 class Contextual extends Highway.Transition {
   in(view, done) {
-    // We reset the scroll position. This can happen here, earlier or later depending on your transition
-    window.scrollTo(0, 0);
-    // Done
-    done();
-
     Tween.set('.site-footer', { opacity: 1, y: 0 });
-    // Animation
-    Tween.fromTo(view, 0.7, { opacity: 0, y: 50 }, { opacity: 1, y: 0, force3D: true });
+    Tween.fromTo(view, 0.7, { autoAlpha: 0, y: 50 }, { autoAlpha: 1, y: 0, force3D: true, onComplete: () => {
+        // Done
+        done();
+      }});
   }
 
   out(view, done) {
-    // Animation
-    Tween.to([view, '.site-footer'], 0.7, { opacity: 0, y: -40, force3D: true, onComplete: done });
+    Tween.to([view, '.site-footer'], 0.7, { opacity: 0, y: -40, force3D: true, onComplete: () => {
+        Tween.set(view, { display: 'none'});
+        // We reset the scroll position. This can happen here, earlier or later depending on your transition
+        window.scrollTo(0, 0);
+        done();
+      }});
   }
 }
 

--- a/docs/src/js/transitions/contextualExample.js
+++ b/docs/src/js/transitions/contextualExample.js
@@ -1,0 +1,26 @@
+// Highway
+import Highway from 'highway';
+
+// GSAP
+import Tween from 'gsap';
+
+// Basic
+class Contextual extends Highway.Transition {
+  in(view, done) {
+    // We reset the scroll position. This can happen here, earlier or later depending on your transition
+    window.scrollTo(0, 0);
+    // Done
+    done();
+
+    Tween.set('.site-footer', { opacity: 1, y: 0 });
+    // Animation
+    Tween.fromTo(view, 0.7, { opacity: 0, y: 50 }, { opacity: 1, y: 0, force3D: true });
+  }
+
+  out(view, done) {
+    // Animation
+    Tween.to([view, '.site-footer'], 0.7, { opacity: 0, y: -40, force3D: true, onComplete: done });
+  }
+}
+
+export default Contextual;

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -11,13 +11,16 @@ export default class Renderer {
    */
   constructor(properties) {
     // We get the view.
-    this.view = document.querySelector('[data-router-view]');
+    this.wrap = document.querySelector('[data-router-wrapper]');
 
     // We save properties of the renderer
     this.properties = properties;
 
     // We get our transition we will use later to show/hide our view.
-    this.Transition = properties.transition ? new properties.transition(this.view) : null;
+    this.Transition = properties.transition ? new properties.transition(this.wrap) : null;
+
+    // Set transition Name
+    this.Transition.name = properties.slug;
   }
 
   /**
@@ -30,19 +33,21 @@ export default class Renderer {
   }
 
   /**
-   * Add view in DOM.
+   * Add view in DOM and set visibility to hidden
    */
   add() {
     // We setup the DOM for our [data-router-view]
-    this.view.setAttribute('data-router-view', this.properties.slug);
-    this.view.innerHTML = this.properties.view.innerHTML;
+    this.wrap.insertAdjacentHTML('beforeend', this.properties.view.outerHTML);
+    this.wrap.lastElementChild.style.visibility = 'hidden';
   }
 
   /**
-   * Remove view in DOM.
+   * Remove old view in DOM and set visibility to visible on new view
    */
   remove() {
-    this.view.innerHTML = '';
+    // We remove the old view. This happens when the user fires removeOldView() in the in transition
+    this.wrap.firstElementChild.remove();
+    this.wrap.lastElementChild.style.visibility = 'visible';
   }
 
   /**
@@ -57,9 +62,10 @@ export default class Renderer {
   /**
    * Add the view in DOM and play an `in` transition if one is defined.
    *
+   * @param {(object|boolean)} contextual - If the transition is changing on the fly
    * @return {object} Promise
    */
-  show() {
+  show(contextual) {
     return new Promise(async resolve => {
       // Update DOM.
       this.update();
@@ -71,7 +77,10 @@ export default class Renderer {
       // The transition is set in your custom renderer with a getter called
       // `transition` that should return the transition object you want to
       // apply to you view. We call the `in` step of this one right now!
-      this.Transition && await this.Transition.show();
+      this.Transition && await this.Transition.show(contextual);
+
+      // the developer can decide when to resolve the in transition, prompting the remove()
+      this.remove();
 
       // The `onEnterCompleted` method if set in your custom renderer is called
       // everytime a transition is over if set. Otherwise it's called right after
@@ -86,9 +95,10 @@ export default class Renderer {
   /**
    * Play an `out` transition if one is defined and remove the view from DOM.
    *
+   * @param {(object|boolean)} contextual - If the transition is changing on the fly
    * @return {object} Promise
    */
-  hide() {
+  hide(contextual) {
     return new Promise(async resolve => {
       // The `onLeave` method if set in your custom renderer is called everytime
       // before a view will be removed from the DOM. This let you do some stuffs
@@ -96,10 +106,7 @@ export default class Renderer {
       this.onLeave && this.onLeave();
 
       // We call the `out` step of your transition right now!
-      this.Transition && await this.Transition.hide();
-
-      // Remove view from DOM.
-      this.remove();
+      this.Transition && await this.Transition.hide(contextual);
 
       // The `onLeaveCompleted` method if set in your custom renderer is called
       // everytime a view is completely removed from the DOM.


### PR DESCRIPTION
The new view is now added as soon as possible and set to visibility: hidden. The old view is removed when the .in transition resolves.

The contextual transition gets set up inside redirect(href, contextual) now, so both clicking a link and using core.redirect(href, transition) can use them. In both cases, pass in false to use the view transition.

I added a quick example and a hunk of JS code to show the core.redirect(href, transition) in action to the top of the examples page. 