### PR TITLE
Omit "--save" flag if npm version >= 5.0.0

### DIFF
--- a/docs/installation.html
+++ b/docs/installation.html
@@ -15,7 +15,7 @@ next_label: Get Started
 <pre><code class="js">npm install --save @dogstudio/highway</code></pre>
 
 <p>If the installed npm version in your pc is less than 5.0.0, then, use:
-<pre><code class="js>npm install --save @dogstudio/highway</code></pre>
+<pre><code class="js">npm install --save @dogstudio/highway</code></pre>
 
 <h2 id="easy-usage"><a href="#easy-usage">Easy Usage</a></h2>
 <p>Highway's package contains a <code>built</code> folder with the ready-to-use <strong>ES5 version</strong> of Highway. The ES6 version of Highway has been compiled into this ES5 version with an optimized <a href="https://github.com/Dogstudio{{ site.pathname }}blob/master/webpack.config.js" target="_blank">configuration</a> we defined so developers don't need to bother with the compilation process.</p>

--- a/docs/installation.html
+++ b/docs/installation.html
@@ -14,6 +14,9 @@ next_label: Get Started
 <h3>Install with NPM:</h3>
 <pre><code class="js">npm install --save @dogstudio/highway</code></pre>
 
+<p>If the installed npm version in your pc is less than 5.0.0, then, use:
+<pre><code class="js>npm install --save @dogstudio/highway</code></pre>
+
 <h2 id="easy-usage"><a href="#easy-usage">Easy Usage</a></h2>
 <p>Highway's package contains a <code>built</code> folder with the ready-to-use <strong>ES5 version</strong> of Highway. The ES6 version of Highway has been compiled into this ES5 version with an optimized <a href="https://github.com/Dogstudio{{ site.pathname }}blob/master/webpack.config.js" target="_blank">configuration</a> we defined so developers don't need to bother with the compilation process.</p>
 <p>Once the package is installed, Highway can be imported in Javascript with the <code>import</code> keyword to have access to <code>Highway.Core</code>, <code>Highway.Renderer</code> and <code>Highway.Transition</code> which are the ready-to-use classes that can be extended.</p>

--- a/docs/installation.html
+++ b/docs/installation.html
@@ -12,9 +12,9 @@ next_label: Get Started
 <pre><code class="js">yarn add @dogstudio/highway</code></pre>
 
 <h3>Install with NPM:</h3>
-<pre><code class="js">npm install --save @dogstudio/highway</code></pre>
+<pre><code class="js">npm install @dogstudio/highway</code></pre>
 
-<p>If the installed npm version in your pc is less than 5.0.0, then, use:
+<p>If the NPM version is less than 5.0.0 in your local machine, use</p>
 <pre><code class="js">npm install --save @dogstudio/highway</code></pre>
 
 <h2 id="easy-usage"><a href="#easy-usage">Easy Usage</a></h2>


### PR DESCRIPTION
As of npm 5.0.0, installed modules are added as a dependency by default, so the --save option is no longer needed.